### PR TITLE
Add basic syscall dispatcher and scheduler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "projectghost"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+x86_64 = "0.14"
+spin = "0.9"
+
+[profile.release]
+panic = "abort"
+
+[[bin]]
+name = "kernel"
+path = "src/kernel/main.rs"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+cargo build --target x86_64-unknown-none --release

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 set -e
+OUT=build
+mkdir -p $OUT/iso
 cargo build --target x86_64-unknown-none --release
+cp target/x86_64-unknown-none/release/kernel $OUT/iso/

--- a/scripts/run-qemu.sh
+++ b/scripts/run-qemu.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 set -e
-qemu-system-x86_64 -m 2G -serial stdio
+mkdir -p logs
+qemu-system-x86_64 -m 2048 -serial file:logs/qemu_output.txt -vga std -kernel build/iso/kernel

--- a/scripts/run-qemu.sh
+++ b/scripts/run-qemu.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+qemu-system-x86_64 -m 2G -serial stdio

--- a/src/drivers/disk.rs
+++ b/src/drivers/disk.rs
@@ -1,0 +1,27 @@
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+static mut STORAGE: [u8; 4096] = [0; 4096];
+static LEN: AtomicUsize = AtomicUsize::new(0);
+const KEY: u8 = 0xAA;
+
+pub fn create_vault() {}
+
+pub fn store_model(data: &[u8]) {
+    let len = data.len().min(4096);
+    unsafe {
+        for i in 0..len {
+            STORAGE[i] = data[i] ^ KEY;
+        }
+    }
+    LEN.store(len, Ordering::SeqCst);
+}
+
+pub fn load_model(buf: &mut [u8]) -> usize {
+    let len = LEN.load(Ordering::SeqCst).min(buf.len());
+    unsafe {
+        for i in 0..len {
+            buf[i] = STORAGE[i] ^ KEY;
+        }
+    }
+    len
+}

--- a/src/drivers/disk.rs
+++ b/src/drivers/disk.rs
@@ -1,13 +1,14 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-static mut STORAGE: [u8; 4096] = [0; 4096];
+const CAPACITY: usize = 4096;
+static mut STORAGE: [u8; CAPACITY] = [0; CAPACITY];
 static LEN: AtomicUsize = AtomicUsize::new(0);
 const KEY: u8 = 0xAA;
 
 pub fn create_vault() {}
 
 pub fn store_model(data: &[u8]) {
-    let len = data.len().min(4096);
+    let len = data.len().min(CAPACITY);
     unsafe {
         for i in 0..len {
             STORAGE[i] = data[i] ^ KEY;

--- a/src/drivers/net.rs
+++ b/src/drivers/net.rs
@@ -1,0 +1,9 @@
+use core::sync::atomic::{AtomicU8, Ordering};
+
+static MODE: AtomicU8 = AtomicU8::new(0);
+
+pub fn enable_isolation() { MODE.store(1, Ordering::SeqCst); }
+pub fn enable_vpn() { MODE.store(2, Ordering::SeqCst); }
+pub fn enable_tor() { MODE.store(3, Ordering::SeqCst); }
+
+pub fn current_mode() -> u8 { MODE.load(Ordering::SeqCst) }

--- a/src/drivers/net.rs
+++ b/src/drivers/net.rs
@@ -1,9 +1,17 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 
+pub enum Mode {
+    Normal = 0,
+    Isolation = 1,
+    Vpn = 2,
+    Tor = 3,
+}
+
 static MODE: AtomicU8 = AtomicU8::new(0);
 
-pub fn enable_isolation() { MODE.store(1, Ordering::SeqCst); }
-pub fn enable_vpn() { MODE.store(2, Ordering::SeqCst); }
-pub fn enable_tor() { MODE.store(3, Ordering::SeqCst); }
+pub fn enable_isolation() { MODE.store(Mode::Isolation as u8, Ordering::SeqCst); }
+pub fn enable_vpn() { MODE.store(Mode::Vpn as u8, Ordering::SeqCst); }
+pub fn enable_tor() { MODE.store(Mode::Tor as u8, Ordering::SeqCst); }
+pub fn disable() { MODE.store(Mode::Normal as u8, Ordering::SeqCst); }
 
 pub fn current_mode() -> u8 { MODE.load(Ordering::SeqCst) }

--- a/src/kernel/main.rs
+++ b/src/kernel/main.rs
@@ -1,0 +1,117 @@
+#![no_std]
+#![no_main]
+
+use core::arch::asm;
+use x86_64::instructions::interrupts;
+use x86_64::instructions::port::Port;
+use x86_64::registers::control::{Cr0, Cr0Flags, Cr3, Cr4, Cr4Flags};
+use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
+use x86_64::structures::paging::PhysFrame;
+use x86_64::PhysAddr;
+
+mod syscalls;
+mod scheduler;
+#[path = "../userland/mod.rs"]
+mod userland;
+
+#[repr(align(4096))]
+struct PageTable([u64; 512]);
+
+const PRESENT: u64 = 1 << 0;
+const WRITABLE: u64 = 1 << 1;
+const HUGE: u64 = 1 << 7;
+
+static mut PML4: PageTable = PageTable([0; 512]);
+static mut PDP: PageTable = PageTable([0; 512]);
+static mut PD: PageTable = PageTable([0; 512]);
+
+static mut IDT: InterruptDescriptorTable = InterruptDescriptorTable::new();
+
+#[repr(C)]
+struct LimineBootloaderInfoResponse {
+    revision: u64,
+    name: *const u8,
+    version: *const u8,
+}
+
+#[repr(C)]
+struct LimineBootloaderInfoRequest {
+    id: [u64; 2],
+    revision: u64,
+    response: *const LimineBootloaderInfoResponse,
+}
+
+#[link_section = ".limine_requests"]
+#[used]
+static BOOTLOADER_INFO_REQUEST: LimineBootloaderInfoRequest = LimineBootloaderInfoRequest {
+    id: [0xf55038d8e2a1202f, 0x279426fcf5f59740],
+    revision: 0,
+    response: core::ptr::null(),
+};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    unsafe {
+        paging_init();
+        idt_init();
+        pit_init();
+    }
+    interrupts::enable();
+
+    userland::init::init();
+
+    loop {
+        unsafe { asm!("hlt"); }
+    }
+}
+
+unsafe fn paging_init() {
+    PML4.0[0] = (&PDP as *const _ as u64) | PRESENT | WRITABLE;
+    PDP.0[0] = (&PD as *const _ as u64) | PRESENT | WRITABLE;
+    for i in 0..512 {
+        PD.0[i] = (i as u64 * 0x200000) | PRESENT | WRITABLE | HUGE;
+    }
+    let pml4_phys = PhysAddr::new(&PML4 as *const _ as u64);
+    let (_, flags) = Cr3::read();
+    Cr3::write(PhysFrame::containing_address(pml4_phys), flags);
+    Cr4::update(|f| *f |= Cr4Flags::PAGE_SIZE_EXTENSIONS);
+    Cr0::update(|f| *f |= Cr0Flags::PAGING);
+}
+
+unsafe fn idt_init() {
+    IDT.divide_error.set_handler_fn(exception);
+    IDT.general_protection_fault.set_handler_fn(exception);
+    IDT[32].set_handler_fn(scheduler::pit_handler);
+    IDT[0x80].set_handler_fn(syscall_handler);
+    IDT.load();
+}
+
+unsafe fn pit_init() {
+    let mut command = Port::new(0x43u16);
+    let mut data = Port::new(0x40u16);
+    command.write(0x36u8);
+    data.write(0u8);
+    data.write(0u8);
+}
+
+extern "x86-interrupt" fn exception(_stack: &mut InterruptStackFrame) {}
+
+extern "x86-interrupt" fn syscall_handler(_stack: &mut InterruptStackFrame) {
+    let num: u64; let a: u64; let b: u64; let c: u64; let d: u64;
+    unsafe {
+        asm!("mov {}, rax", out(reg) num);
+        asm!("mov {}, rdi", out(reg) a);
+        asm!("mov {}, rsi", out(reg) b);
+        asm!("mov {}, rdx", out(reg) c);
+        asm!("mov {}, r10", out(reg) d);
+        let ret = syscalls::dispatch(num, a, b, c, d);
+        asm!("mov rax, {}", in(reg) ret);
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {
+        unsafe { asm!("hlt"); }
+    }
+}

--- a/src/kernel/main.rs
+++ b/src/kernel/main.rs
@@ -11,6 +11,11 @@ use x86_64::PhysAddr;
 
 mod syscalls;
 mod scheduler;
+mod mem;
+#[path = "../drivers/disk.rs"]
+pub mod disk;
+#[path = "../drivers/net.rs"]
+pub mod net;
 #[path = "../userland/mod.rs"]
 mod userland;
 
@@ -52,6 +57,7 @@ static BOOTLOADER_INFO_REQUEST: LimineBootloaderInfoRequest = LimineBootloaderIn
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     unsafe {
+        mem::init();
         paging_init();
         idt_init();
         pit_init();
@@ -81,6 +87,7 @@ unsafe fn paging_init() {
 unsafe fn idt_init() {
     IDT.divide_error.set_handler_fn(exception);
     IDT.general_protection_fault.set_handler_fn(exception);
+    IDT.page_fault.set_handler_fn(exception);
     IDT[32].set_handler_fn(scheduler::pit_handler);
     IDT[0x80].set_handler_fn(syscall_handler);
     IDT.load();

--- a/src/kernel/mem.rs
+++ b/src/kernel/mem.rs
@@ -1,0 +1,22 @@
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+const HEAP_SIZE: usize = 64 * 1024;
+static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
+static NEXT: AtomicUsize = AtomicUsize::new(0);
+
+pub fn init() {}
+
+pub fn kmalloc(size: usize) -> *mut u8 {
+    let mut current = NEXT.load(Ordering::SeqCst);
+    loop {
+        if current + size > HEAP_SIZE {
+            return core::ptr::null_mut();
+        }
+        match NEXT.compare_exchange(current, current + size, Ordering::SeqCst, Ordering::SeqCst) {
+            Ok(_) => unsafe { return HEAP.as_mut_ptr().add(current); },
+            Err(v) => current = v,
+        }
+    }
+}
+
+pub fn kfree(_ptr: *mut u8) {}

--- a/src/kernel/scheduler.rs
+++ b/src/kernel/scheduler.rs
@@ -1,0 +1,42 @@
+use core::sync::atomic::{AtomicUsize, Ordering};
+use x86_64::structures::idt::InterruptStackFrame;
+
+pub type Entry = extern "C" fn();
+
+pub struct Tcb {
+    pub entry: Entry,
+    pub active: bool,
+}
+
+static mut TASKS: [Tcb; 4] = [
+    Tcb { entry: idle, active: true },
+    Tcb { entry: idle, active: false },
+    Tcb { entry: idle, active: false },
+    Tcb { entry: idle, active: false },
+];
+
+static CURRENT: AtomicUsize = AtomicUsize::new(0);
+
+pub fn add_task(entry: Entry) -> Option<usize> {
+    unsafe {
+        for (i, t) in TASKS.iter_mut().enumerate().skip(1) {
+            if !t.active {
+                t.entry = entry;
+                t.active = true;
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
+pub extern "x86-interrupt" fn pit_handler(_stack: &mut InterruptStackFrame) {
+    let next = (CURRENT.load(Ordering::SeqCst) + 1) % unsafe { TASKS.len() };
+    CURRENT.store(next, Ordering::SeqCst);
+}
+
+pub fn current_task() -> Entry {
+    unsafe { TASKS[CURRENT.load(Ordering::SeqCst)].entry }
+}
+
+extern "C" fn idle() {}

--- a/src/kernel/scheduler.rs
+++ b/src/kernel/scheduler.rs
@@ -3,16 +3,17 @@ use x86_64::structures::idt::InterruptStackFrame;
 
 pub type Entry = extern "C" fn();
 
-pub struct Tcb {
+pub struct TaskControlBlock {
     pub entry: Entry,
     pub active: bool,
+    pub pid: u32,
 }
 
-static mut TASKS: [Tcb; 4] = [
-    Tcb { entry: idle, active: true },
-    Tcb { entry: idle, active: false },
-    Tcb { entry: idle, active: false },
-    Tcb { entry: idle, active: false },
+static mut TASKS: [TaskControlBlock; 4] = [
+    TaskControlBlock { entry: idle, active: true, pid: 0 },
+    TaskControlBlock { entry: idle, active: false, pid: 1 },
+    TaskControlBlock { entry: idle, active: false, pid: 2 },
+    TaskControlBlock { entry: idle, active: false, pid: 3 },
 ];
 
 static CURRENT: AtomicUsize = AtomicUsize::new(0);

--- a/src/kernel/syscalls.rs
+++ b/src/kernel/syscalls.rs
@@ -1,4 +1,5 @@
 use core::ptr;
+use crate::{disk, scheduler};
 
 pub type SysResult = u64;
 
@@ -9,6 +10,10 @@ pub const SYS_CLOSE: u64 = 3;
 pub const SYS_SPAWN: u64 = 4;
 pub const SYS_EXIT: u64 = 5;
 pub const SYS_LOAD_AI_MODEL: u64 = 6;
+pub const SYS_ENABLE_ISOLATION: u64 = 7;
+pub const SYS_ENABLE_VPN: u64 = 8;
+pub const SYS_ENABLE_TOR: u64 = 9;
+pub const SYS_GET_NET_MODE: u64 = 10;
 
 pub fn dispatch(num: u64, a: u64, b: u64, c: u64, d: u64) -> SysResult {
     match num {
@@ -19,39 +24,60 @@ pub fn dispatch(num: u64, a: u64, b: u64, c: u64, d: u64) -> SysResult {
         SYS_SPAWN => sys_spawn(a as *const u8),
         SYS_EXIT => sys_exit(a),
         SYS_LOAD_AI_MODEL => sys_load_ai_model(a as *const u8, b as *mut u8, c as usize),
+        SYS_ENABLE_ISOLATION => { crate::net::enable_isolation(); 0 }
+        SYS_ENABLE_VPN => { crate::net::enable_vpn(); 0 }
+        SYS_ENABLE_TOR => { crate::net::enable_tor(); 0 }
+        SYS_GET_NET_MODE => crate::net::current_mode() as u64,
         _ => 0,
     }
 }
 
 fn sys_write(_fd: u64, _buf: *const u8, _len: usize) -> SysResult {
-    // stub write
-    0
+    let slice = unsafe { core::slice::from_raw_parts(_buf, _len) };
+    let vga = 0xb8000 as *mut u8;
+    for (i, b) in slice.iter().enumerate() {
+        unsafe {
+            ptr::write(vga.add(i * 2), *b);
+            ptr::write(vga.add(i * 2 + 1), 0x07);
+        }
+    }
+    _len as u64
 }
 
 fn sys_read(_fd: u64, _buf: *mut u8, _len: usize) -> SysResult {
-    0
-}
-
-fn sys_open(_path: *const u8, _flags: u64) -> SysResult {
-    0
-}
-
-fn sys_close(_fd: u64) -> SysResult {
-    0
-}
-
-fn sys_spawn(_path: *const u8) -> SysResult {
-    0
-}
-
-fn sys_exit(_code: u64) -> SysResult {
-    loop {}
-}
-
-fn sys_load_ai_model(_name: *const u8, _buf: *mut u8, _len: usize) -> SysResult {
-    // stub: just zero out buffer
     for i in 0.._len {
         unsafe { ptr::write(_buf.add(i), 0); }
     }
     0
+}
+
+fn sys_open(_path: *const u8, _flags: u64) -> SysResult {
+    if _path.is_null() { return 0; }
+    1
+}
+
+fn sys_close(_fd: u64) -> SysResult {
+    let _ = _fd;
+    0
+}
+
+fn sys_spawn(_path: *const u8) -> SysResult {
+    let entry = unsafe { core::mem::transmute::<*const u8, scheduler::Entry>(_path) };
+    if scheduler::add_task(entry).is_some() { 0 } else { 1 }
+}
+
+fn sys_exit(_code: u64) -> SysResult {
+    let _ = _code;
+    loop {}
+}
+
+fn sys_load_ai_model(_name: *const u8, _buf: *mut u8, _len: usize) -> SysResult {
+    let name = if _name.is_null() { &[][..] } else { unsafe {
+        let mut len = 0;
+        while ptr::read(_name.add(len)) != 0 { len += 1; }
+        core::slice::from_raw_parts(_name, len)
+    } };
+    let _ = name;
+    let slice = unsafe { core::slice::from_raw_parts_mut(_buf, _len) };
+    disk::load_model(slice) as u64
 }

--- a/src/kernel/syscalls.rs
+++ b/src/kernel/syscalls.rs
@@ -1,0 +1,57 @@
+use core::ptr;
+
+pub type SysResult = u64;
+
+pub const SYS_WRITE: u64 = 0;
+pub const SYS_READ: u64 = 1;
+pub const SYS_OPEN: u64 = 2;
+pub const SYS_CLOSE: u64 = 3;
+pub const SYS_SPAWN: u64 = 4;
+pub const SYS_EXIT: u64 = 5;
+pub const SYS_LOAD_AI_MODEL: u64 = 6;
+
+pub fn dispatch(num: u64, a: u64, b: u64, c: u64, d: u64) -> SysResult {
+    match num {
+        SYS_WRITE => sys_write(a, b as *const u8, c as usize),
+        SYS_READ => sys_read(a, b as *mut u8, c as usize),
+        SYS_OPEN => sys_open(a as *const u8, b as u64),
+        SYS_CLOSE => sys_close(a),
+        SYS_SPAWN => sys_spawn(a as *const u8),
+        SYS_EXIT => sys_exit(a),
+        SYS_LOAD_AI_MODEL => sys_load_ai_model(a as *const u8, b as *mut u8, c as usize),
+        _ => 0,
+    }
+}
+
+fn sys_write(_fd: u64, _buf: *const u8, _len: usize) -> SysResult {
+    // stub write
+    0
+}
+
+fn sys_read(_fd: u64, _buf: *mut u8, _len: usize) -> SysResult {
+    0
+}
+
+fn sys_open(_path: *const u8, _flags: u64) -> SysResult {
+    0
+}
+
+fn sys_close(_fd: u64) -> SysResult {
+    0
+}
+
+fn sys_spawn(_path: *const u8) -> SysResult {
+    0
+}
+
+fn sys_exit(_code: u64) -> SysResult {
+    loop {}
+}
+
+fn sys_load_ai_model(_name: *const u8, _buf: *mut u8, _len: usize) -> SysResult {
+    // stub: just zero out buffer
+    for i in 0.._len {
+        unsafe { ptr::write(_buf.add(i), 0); }
+    }
+    0
+}

--- a/src/userland/init.rs
+++ b/src/userland/init.rs
@@ -1,0 +1,5 @@
+use super::shell;
+
+pub fn init() {
+    shell::start();
+}

--- a/src/userland/mod.rs
+++ b/src/userland/mod.rs
@@ -1,0 +1,3 @@
+pub mod sys_bindings;
+pub mod shell;
+pub mod init;

--- a/src/userland/shell.rs
+++ b/src/userland/shell.rs
@@ -1,0 +1,9 @@
+use super::sys_bindings;
+
+pub fn start() {
+    let msg = b"ProjectGhost shell\n";
+    unsafe {
+        sys_bindings::write(1, msg.as_ptr(), msg.len() as u64);
+    }
+    loop {}
+}

--- a/src/userland/shell.rs
+++ b/src/userland/shell.rs
@@ -1,9 +1,19 @@
 use super::sys_bindings;
 
+fn print(s: &str) {
+    unsafe { sys_bindings::write(1, s.as_ptr(), s.len() as u64); }
+}
+
 pub fn start() {
-    let msg = b"ProjectGhost shell\n";
-    unsafe {
-        sys_bindings::write(1, msg.as_ptr(), msg.len() as u64);
+    print("ProjectGhost shell\n> ");
+    let mut buf = [0u8; 64];
+    loop {
+        unsafe { sys_bindings::read(0, buf.as_mut_ptr(), buf.len() as u64); }
+        match core::str::from_utf8(&buf).unwrap_or("").trim() {
+            "ghost-mode" => {
+                sys_bindings::enable_tor();
+            }
+            _ => {}
+        }
     }
-    loop {}
 }

--- a/src/userland/sys_bindings.rs
+++ b/src/userland/sys_bindings.rs
@@ -26,6 +26,11 @@ pub fn load_ai_model(name: *const u8, buf: *mut u8, len: u64) -> u64 {
     syscall(6, name as u64, buf as u64, len, 0)
 }
 
+pub fn enable_isolation() { let _ = syscall(7, 0, 0, 0, 0); }
+pub fn enable_vpn() { let _ = syscall(8, 0, 0, 0, 0); }
+pub fn enable_tor() { let _ = syscall(9, 0, 0, 0, 0); }
+pub fn get_net_mode() -> u64 { syscall(10, 0, 0, 0, 0) }
+
 #[inline(always)]
 fn syscall(n: u64, a: u64, b: u64, c: u64, d: u64) -> u64 {
     let ret: u64;

--- a/src/userland/sys_bindings.rs
+++ b/src/userland/sys_bindings.rs
@@ -1,0 +1,44 @@
+pub fn write(fd: u64, buf: *const u8, len: u64) -> u64 {
+    syscall(0, fd, buf as u64, len, 0)
+}
+
+pub fn read(fd: u64, buf: *mut u8, len: u64) -> u64 {
+    syscall(1, fd, buf as u64, len, 0)
+}
+
+pub fn open(path: *const u8, flags: u64) -> u64 {
+    syscall(2, path as u64, flags, 0, 0)
+}
+
+pub fn close(fd: u64) -> u64 {
+    syscall(3, fd, 0, 0, 0)
+}
+
+pub fn spawn(path: *const u8) -> u64 {
+    syscall(4, path as u64, 0, 0, 0)
+}
+
+pub fn exit(code: u64) -> u64 {
+    syscall(5, code, 0, 0, 0)
+}
+
+pub fn load_ai_model(name: *const u8, buf: *mut u8, len: u64) -> u64 {
+    syscall(6, name as u64, buf as u64, len, 0)
+}
+
+#[inline(always)]
+fn syscall(n: u64, a: u64, b: u64, c: u64, d: u64) -> u64 {
+    let ret: u64;
+    unsafe {
+        core::arch::asm!(
+            "int 0x80",
+            in("rax") n,
+            in("rdi") a,
+            in("rsi") b,
+            in("rdx") c,
+            in("r10") d,
+            lateout("rax") ret,
+        );
+    }
+    ret
+}


### PR DESCRIPTION
## Summary
- Expand kernel with syscall dispatcher and PIT-driven scheduler
- Provide userland bindings, shell init, and simple drivers for disk and network
- Add build and run scripts for kernel

## Testing
- `cargo build --target x86_64-unknown-none --release` *(fails: failed to download from crates.io 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af3e23625c832a905c7016131995c4